### PR TITLE
Fix devicedeployment.c on 64-bit OS X

### DIFF
--- a/devicedeployment.c
+++ b/devicedeployment.c
@@ -5,11 +5,11 @@
 #include <simplemotion_private.h>
 #include <math.h>
 
-#ifdef __unix__
+#if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
 void sleep_ms(int millisecs)
 {
-    msleep(millisecs);
+    usleep(millisecs*1000);
 }
 #else
 #include <windows.h>
@@ -321,7 +321,7 @@ FirmwareUploadStatus verifyFirmwareData(smuint8 *data, smuint32 numbytes, int co
     smuint32 cksumOffset=4+2+2+4+4+primaryMCUSize+secondaryMCUSize;
     if(cksumOffset>numbytes-4)
         return FWInvalidFile;
-    cksum=((smuint32*)((smuint32)data+cksumOffset))[0];
+    cksum=((smuint32*)(data+cksumOffset))[0];
 
     for(i=0;i< numbytes-4;i++)
     {


### PR DESCRIPTION
This PR includes the following fixes:

- correct defines
- msleep changed to usleep
- don't cast pointer to an integer (fails on 64-bit)